### PR TITLE
Add snippets/completions for main / source file paths

### DIFF
--- a/bower/utils/bowerrc.py
+++ b/bower/utils/bowerrc.py
@@ -1,0 +1,29 @@
+import os
+import json
+from os.path import expanduser
+
+class BowerRC():
+  def exists():
+    if self.get_path() != None:
+      return true
+    else:
+      return false
+
+  def get_path(this):
+    bowerrc = ".bowerrc"
+    project_home_dir = "" # Figure this out
+
+    projectrc = os.path.join(project_home_dir, bowerrc)
+    homerc = os.path.join(expanduser("~"), bowerrc)
+
+    for path in [projectrc, homerc]:
+      if os.path.exists(path)
+        return path
+
+    return None
+
+  def read(this):
+    if self.exists():
+      return json.loads(self.get_path())
+    else:
+      return {}

--- a/bower/utils/bowerrc.py
+++ b/bower/utils/bowerrc.py
@@ -2,28 +2,22 @@ import os
 import json
 from os.path import expanduser
 
+
 class BowerRC():
-  def exists():
-    if self.get_path() != None:
-      return true
-    else:
-      return false
+    def get_path(self, projectdir=""):
+        bowerrc = ".bowerrc"
+        projectrc = os.path.join(projectdir, bowerrc)
+        homerc = os.path.join(expanduser("~"), bowerrc)
 
-  def get_path(this):
-    bowerrc = ".bowerrc"
-    project_home_dir = "" # Figure this out
+        for path in [projectrc, homerc]:
+            if os.path.exists(path):
+                return path
 
-    projectrc = os.path.join(project_home_dir, bowerrc)
-    homerc = os.path.join(expanduser("~"), bowerrc)
+        return None
 
-    for path in [projectrc, homerc]:
-      if os.path.exists(path)
-        return path
-
-    return None
-
-  def read(this):
-    if self.exists():
-      return json.loads(self.get_path())
-    else:
-      return {}
+    def read(self, projectdir):
+        path = self.get_path(projectdir)
+        if path is not None:
+            return json.loads(open(path).read())
+        else:
+            return {}

--- a/bower/utils/package_definition.py
+++ b/bower/utils/package_definition.py
@@ -24,8 +24,10 @@ class PackageDefinition:
             return os.path.join(self.projectdir, "components")
 
     def read(self, package_name):
-        print self.definition_path()
-        print package_name
         path = os.path.join(self.definition_path(), package_name, "component.json")
-        print path
-        return json.loads(open(path).read())
+        
+        if os.path.exists(path):
+            return json.loads(open(path).read())
+        else:
+            print "[Bower]: " + package_name + " doesn't have a component.json - Please submit an issue to the " + package_name + " project to tell the author." 
+            return {}

--- a/bower/utils/package_definition.py
+++ b/bower/utils/package_definition.py
@@ -1,17 +1,30 @@
 import json
+import os
 from bower.utils.bowerrc import BowerRC
 
-class PackageDefinition():
-  def definition_path():
-    bowerrc = BowerRC()
-    
-    if bowerrc.exists() and bowerrc.read().has_key('directory'):
-      return bowerrc.read()['directory']
-    else
-      return "components"
 
-  def read(self, package_name):
-    path = self.definition_path() + "/" + package_name + "/component.json"
+class PackageDefinition:
+    def __init__(self, projectdir):
+        self.projectdir = projectdir
 
-    definition = open(path)
-    return json.loads(definition)
+    def get_installed_packages(self):
+        defpath = self.definition_path()
+        if not os.path.isdir(defpath):
+            return []
+        return [name for name in os.listdir(defpath) if os.path.isdir(os.path.join(defpath, name))]
+
+    def definition_path(self):
+        bowerrc = BowerRC()
+        bowercpath = bowerrc.read(self.projectdir)
+
+        if bowercpath is not None and 'directory' in bowercpath:
+            return bowerrc.read(self.projectdir)['directory']
+        else:
+            return os.path.join(self.projectdir, "components")
+
+    def read(self, package_name):
+        print self.definition_path()
+        print package_name
+        path = os.path.join(self.definition_path(), package_name, "component.json")
+        print path
+        return json.loads(open(path).read())

--- a/bower/utils/package_definition.py
+++ b/bower/utils/package_definition.py
@@ -1,0 +1,17 @@
+import json
+from bower.utils.bowerrc import BowerRC
+
+class PackageDefinition():
+  def definition_path():
+    bowerrc = BowerRC()
+    
+    if bowerrc.exists() and bowerrc.read().has_key('directory'):
+      return bowerrc.read()['directory']
+    else
+      return "components"
+
+  def read(self, package_name):
+    path = self.definition_path() + "/" + package_name
+
+    definition = open(path)
+    return json.loads(definition)

--- a/bower/utils/package_definition.py
+++ b/bower/utils/package_definition.py
@@ -16,9 +16,10 @@ class PackageDefinition:
     def definition_path(self):
         bowerrc = BowerRC()
         bowercpath = bowerrc.read(self.projectdir)
-
-        if bowercpath is not None and 'directory' in bowercpath:
-            return bowerrc.read(self.projectdir)['directory']
+        
+        if 'directory' in bowercpath:
+            bower_directory = bowerrc.read(self.projectdir)['directory']
+            return os.path.join(self.projectdir, bower_directory)
         else:
             return os.path.join(self.projectdir, "components")
 

--- a/bower/utils/package_definition.py
+++ b/bower/utils/package_definition.py
@@ -11,7 +11,7 @@ class PackageDefinition():
       return "components"
 
   def read(self, package_name):
-    path = self.definition_path() + "/" + package_name
+    path = self.definition_path() + "/" + package_name + "/component.json"
 
     definition = open(path)
     return json.loads(definition)

--- a/bower_completions.py
+++ b/bower_completions.py
@@ -14,13 +14,25 @@ class BowerCompletions(sublime_plugin.EventListener):
         if not view.match_selector(locations[0], "text.html - source"):
             return []
 
-        print 'test'
-
         pt = locations[0] - len(prefix) - 1
         ch = view.substr(sublime.Region(pt, pt + 1))
+
         if ch != '`':
             return []
 
-        self.packageDefinition = PackageDefinition(os.path.join(view.window().folders()[0]))
+        packages = self.build_package_list(os.path.join(view.window().folders()[0]))
+            
+        return (packages, sublime.INHIBIT_WORD_COMPLETIONS | sublime.INHIBIT_EXPLICIT_COMPLETIONS)
 
-        return ([self.get_completion(self.packageDefinition.read(pkg)["main"], pkg) for pkg in self.packageDefinition.get_installed_packages()], sublime.INHIBIT_WORD_COMPLETIONS | sublime.INHIBIT_EXPLICIT_COMPLETIONS)
+    def build_package_list(self, path):
+        self.packageDefinition = PackageDefinition(path)
+
+        packages = []
+        for pkg in self.packageDefinition.get_installed_packages():
+            if self.packageDefinition.read(pkg).has_key('main'):
+                packages.append(self.get_completion(self.packageDefinition.read(pkg)["main"], pkg))
+            else:
+                print "[Bower]: " + pkg + " doesn't have a correctly formatted component.json file (missing 'main')"
+        return packages
+
+

--- a/bower_completions.py
+++ b/bower_completions.py
@@ -1,0 +1,26 @@
+import sublime
+import sublime_plugin
+import os
+from bower.utils.package_definition import PackageDefinition
+
+
+class BowerCompletions(sublime_plugin.EventListener):
+
+    def get_completion(self, file, name):
+        path = os.path.join(self.packageDefinition.definition_path(), file.replace("./", ""))
+        return (name +"\tbower", "<script src=\"" + path + "\"></script>")
+
+    def on_query_completions(self, view, prefix, locations):
+        if not view.match_selector(locations[0], "text.html - source"):
+            return []
+
+        print 'test'
+
+        pt = locations[0] - len(prefix) - 1
+        ch = view.substr(sublime.Region(pt, pt + 1))
+        if ch != '`':
+            return []
+
+        self.packageDefinition = PackageDefinition(os.path.join(view.window().folders()[0]))
+
+        return ([self.get_completion(self.packageDefinition.read(pkg)["main"], pkg) for pkg in self.packageDefinition.get_installed_packages()], sublime.INHIBIT_WORD_COMPLETIONS | sublime.INHIBIT_EXPLICIT_COMPLETIONS)


### PR DESCRIPTION
Consider the following interface:

```
bower<tab>
```

Should autocomplete / list the available packages that you have installed in a contextual menu (not sure if possible? - need to research).
Pressing `<enter>` should complete the string into `bower:packageName`

```
bower:packageName<tab>
```

Should insert the paths(s) of the main files outlined in the packages' `component.json` file.
If you're currently focused on a HTML file, it should:
- Write `<script src="components/jquery/jquery.js"></script>` for scripts
- Write `<link rel="stylesheet" href="comonents/normalize-css/normalize.css">` for stylesheets

If you're currently focused on any other kind of file, paste the raw path. 

If anyone wants to start implementing this, that'd be gnarly. Otherwise, I'll roll my sleeves up and sort it out when I get the chance. 
