### PR TITLE
First pass at the completion for bower packages

### DIFF
--- a/bower/utils/bowerrc.py
+++ b/bower/utils/bowerrc.py
@@ -2,28 +2,22 @@ import os
 import json
 from os.path import expanduser
 
+
 class BowerRC():
-  def exists():
-    if self.get_path() != None:
-      return true
-    else:
-      return false
+    def get_path(self, projectdir=""):
+        bowerrc = ".bowerrc"
+        projectrc = os.path.join(projectdir, bowerrc)
+        homerc = os.path.join(expanduser("~"), bowerrc)
 
-  def get_path(this):
-    bowerrc = ".bowerrc"
-    project_home_dir = "" # Figure this out
+        for path in [projectrc, homerc]:
+            if os.path.exists(path):
+                return path
 
-    projectrc = os.path.join(project_home_dir, bowerrc)
-    homerc = os.path.join(expanduser("~"), bowerrc)
+        return None
 
-    for path in [projectrc, homerc]:
-      if os.path.exists(path)
-        return path
-
-    return None
-
-  def read(this):
-    if self.exists():
-      return json.loads(self.get_path())
-    else:
-      return {}
+    def read(self, projectdir):
+        path = self.get_path(projectdir)
+        if path is not None:
+            return json.loads(open(path).read())
+        else:
+            return {}

--- a/bower/utils/package_definition.py
+++ b/bower/utils/package_definition.py
@@ -1,17 +1,30 @@
 import json
+import os
 from bower.utils.bowerrc import BowerRC
 
-class PackageDefinition():
-  def definition_path():
-    bowerrc = BowerRC()
-    
-    if bowerrc.exists() and bowerrc.read().has_key('directory'):
-      return bowerrc.read()['directory']
-    else
-      return "components"
 
-  def read(self, package_name):
-    path = self.definition_path() + "/" + package_name + "/component.json"
+class PackageDefinition:
+    def __init__(self, projectdir):
+        self.projectdir = projectdir
 
-    definition = open(path)
-    return json.loads(definition)
+    def get_installed_packages(self):
+        defpath = self.definition_path()
+        if not os.path.isdir(defpath):
+            return []
+        return [name for name in os.listdir(defpath) if os.path.isdir(os.path.join(defpath, name))]
+
+    def definition_path(self):
+        bowerrc = BowerRC()
+        bowercpath = bowerrc.read(self.projectdir)
+
+        if bowercpath is not None and 'directory' in bowercpath:
+            return bowerrc.read(self.projectdir)['directory']
+        else:
+            return os.path.join(self.projectdir, "components")
+
+    def read(self, package_name):
+        print self.definition_path()
+        print package_name
+        path = os.path.join(self.definition_path(), package_name, "component.json")
+        print path
+        return json.loads(open(path).read())

--- a/bower_completions.py
+++ b/bower_completions.py
@@ -1,0 +1,26 @@
+import sublime
+import sublime_plugin
+import os
+from bower.utils.package_definition import PackageDefinition
+
+
+class BowerCompletions(sublime_plugin.EventListener):
+
+    def get_completion(self, file, name):
+        path = os.path.join(self.packageDefinition.definition_path(), file.replace("./", ""))
+        return (name +"\tbower", "<script src=\"" + path + "\"></script>")
+
+    def on_query_completions(self, view, prefix, locations):
+        if not view.match_selector(locations[0], "text.html - source"):
+            return []
+
+        print 'test'
+
+        pt = locations[0] - len(prefix) - 1
+        ch = view.substr(sublime.Region(pt, pt + 1))
+        if ch != '`':
+            return []
+
+        self.packageDefinition = PackageDefinition(os.path.join(view.window().folders()[0]))
+
+        return ([self.get_completion(self.packageDefinition.read(pkg)["main"], pkg) for pkg in self.packageDefinition.get_installed_packages()], sublime.INHIBIT_WORD_COMPLETIONS | sublime.INHIBIT_EXPLICIT_COMPLETIONS)


### PR DESCRIPTION
So

this sort of works.
Not very user friendly.

To make it work you have to goto 

Sublime text 2 menu -> settings default (user does not seem to work)

find the line that reads

"auto_complete_triggers": [ {"selector": "text.html", "characters": "<"} ],

Edit it to read

"auto_complete_triggers": [ {"selector": "text.html", "characters": "<`"} ],

now in any html file you should be able to type ` and get al ist of installed packages. I have only tested it with a local components folder as i am lazy and working in sublimes un documented apis drove me insane.

Known limitations - 
Will only work if you have a project open with 1 folders - it currently reads the top folder by default, need to figure out how to make this smarter

It does nothing when it can not find a directory or a folder or something. 

No idea if it works with an rc file (i assume it will)

It currently leaves around a ` after the insertion, dove into sublimes documentation again for this, but came up empty handed will keep looking.

Obviously the ` and editing a default settings file is less than idea, need to figure out how to add our own completion handler.

Not very efficient, it hits the file system a lot. We should do the checks for the project folders once on project load (if such an event exists in sublime) then we just have to poll the directory to get the list of projects i was kind of hoping bower kept around an installed packages .json which would mean only opening 1 fd (yay)

Oh an just for completeness sake this is a pass at #13 
