### PR TITLE
Update search URL

### DIFF
--- a/bower/commands/discover.py
+++ b/bower/commands/discover.py
@@ -3,4 +3,4 @@ import sublime_plugin
 
 class DiscoverPackageCommand(sublime_plugin.WindowCommand):
     def run(self):
-        self.window.run_command('open_url', {'url': 'http://sindresorhus.com/bower-components/'})
+        self.window.run_command('open_url', {'url': 'http://bower.io/search/'})


### PR DESCRIPTION
Bower search is now housed at http://bower.io/search/
